### PR TITLE
Goaltogo fix

### DIFF
--- a/R/PlayByPlayBoxScore.R
+++ b/R/PlayByPlayBoxScore.R
@@ -1119,7 +1119,10 @@ game_play_by_play <- function(GameID) {
   
   # Goal to Go
   
-  PBP$GoalToGo <- ifelse(PBP$yrdline100 <= 10, 1, 0)
+  PBP$GoalToGo <- ifelse(PBP$SideofField != PBP$posteam & 
+                        ((PBP$ydstogo == PBP$yrdline100) |
+                        (PBP$ydstogo <= 1 & PBP$yrdline100 == 1)),
+                         1,0)
   ##################
   
   ## Unlisting Listed Columns 


### PR DESCRIPTION
Updated logic for field.  2016 ex: 956 plays misclassified before as GoalToGo (such as when a team starts 1st and 15, gets 6 yards, but can still get a first down then) and 164 plays misclassified before as not GoalToGo (was 1st and 5, 5 yards to the goal, but then a penalty, 1st and 15).