### PR TITLE
Airepa

### DIFF
--- a/R/PlayByPlayBoxScore.R
+++ b/R/PlayByPlayBoxScore.R
@@ -13,7 +13,7 @@
 #' @param GameID (character or numeric) A 10 digit game ID associated with a 
 #' given NFL game.
 #' @details Through list manipulation using the do.call and rbind functions
-#'  a 10 column dataframe with basic information populates directly from the NFL 
+#'  a 13 column dataframe with basic information populates directly from the NFL 
 #'  JSON API.  These columns include the following:
 #' \itemize{
 #'  \item{"Drive"} - Drive number
@@ -172,6 +172,8 @@
 #'  start of the play
 #'  \item{"EPA"} - Expected points added with respect to the possession
 #'  team considering the result of the play
+#'  \item{"airEPA"} - Expected points added from air yards
+#'  \item{"yacEPA"} - Expected points added from yards after catch
 #'  \item{"Home_WP_pre"} - The win probability for the home team at the start
 #'  of the play
 #'  \item{"Away_WP_pre"} - The win probability for the away team at the start
@@ -186,7 +188,7 @@
 #'  
 #'  }
 #'  
-#' @return A dataframe with 98 columns specifying various statistics and 
+#' @return A dataframe with 99 columns specifying various statistics and 
 #' outcomes associated with each play of the specified NFL game.
 #' @examples
 #' # Parsed play-by-play of the final game in the 2015 NFL season 
@@ -1486,7 +1488,7 @@ game_play_by_play <- function(GameID) {
          "No_Score_Prob","Opp_Field_Goal_Prob","Opp_Safety_Prob",
          "Opp_Touchdown_Prob","Field_Goal_Prob","Safety_Prob",
          "Touchdown_Prob","ExPoint_Prob","TwoPoint_Prob",
-         "ExpPts","EPA","Home_WP_pre",  "Away_WP_pre", "Home_WP_post", 
+         "ExpPts","EPA","airEPA","yacEPA","Home_WP_pre",  "Away_WP_pre", "Home_WP_post", 
          "Away_WP_post","Win_Prob","WPA")]
 }
 
@@ -1507,7 +1509,7 @@ game_play_by_play <- function(GameID) {
 #' from a given season.  This dataframe is prime for use with the dplyr and 
 #' plyr packages.
 #' @return A dataframe contains all the play-by-play information for a single
-#'      season.  This includes all the 88 variables collected in our 
+#'      season.  This includes all the 99 variables collected in our 
 #'      game_play_by_play function (see documentation for game_play_by_play for
 #'      details) and a column for the Season.
 #' @examples

--- a/man/expected_points.Rd
+++ b/man/expected_points.Rd
@@ -2,8 +2,9 @@
 % Please edit documentation in R/ExpectedPointAndWinProbability.R
 \name{expected_points}
 \alias{expected_points}
-\title{Expected point function to add an expected point variable for each play in
-the play by play}
+\title{Expected point function to calculate expected points for each play in
+the play by play, and the expected points added in three ways, 
+basic EPA, air yards EPA, and yards after catch EPA}
 \usage{
 expected_points(dataset)
 }
@@ -12,7 +13,7 @@ expected_points(dataset)
 game_play_by_play function}
 }
 \value{
-The input dataframe with the addition of an expected point column
+The input dataframe with the addition of expected points columns
 }
 \description{
 This function takes in the output of the game level play by play

--- a/man/game_play_by_play.Rd
+++ b/man/game_play_by_play.Rd
@@ -11,7 +11,7 @@ game_play_by_play(GameID)
 given NFL game.}
 }
 \value{
-A dataframe with 98 columns specifying various statistics and 
+A dataframe with 99 columns specifying various statistics and 
 outcomes associated with each play of the specified NFL game.
 }
 \description{
@@ -22,7 +22,7 @@ This function intakes the JSON play-by-play data of a single
 }
 \details{
 Through list manipulation using the do.call and rbind functions
- a 10 column dataframe with basic information populates directly from the NFL 
+ a 13 column dataframe with basic information populates directly from the NFL 
  JSON API.  These columns include the following:
 \itemize{
  \item{"Drive"} - Drive number
@@ -181,6 +181,8 @@ The added variables are specified below:
  start of the play
  \item{"EPA"} - Expected points added with respect to the possession
  team considering the result of the play
+ \item{"airEPA"} - Expected points added from air yards
+ \item{"yacEPA"} - Expected points added from yards after catch
  \item{"Home_WP_pre"} - The win probability for the home team at the start
  of the play
  \item{"Away_WP_pre"} - The win probability for the away team at the start

--- a/man/season_play_by_play.Rd
+++ b/man/season_play_by_play.Rd
@@ -16,7 +16,7 @@ three weeks of play-by-play will be scraped from the associated season.}
 }
 \value{
 A dataframe contains all the play-by-play information for a single
-     season.  This includes all the 88 variables collected in our 
+     season.  This includes all the 99 variables collected in our 
      game_play_by_play function (see documentation for game_play_by_play for
      details) and a column for the Season.
 }


### PR DESCRIPTION
Updated the expected_points and game_play_by_play functions to now include airEPA and yacEPA for all pass attempts.  Calculation uses the AirYards to determine what the expected points would be at the catch, adjusting for change of downs, possession, etc.  The idea for airEPA and yacEPA on incomplete passes is to provide the idea of what could've been if the receiver caught the ball (airEPA) and the cost of dropping/missing (yacEPA).  Also fixed the EPA for failed PAT attempts.