### PR TITLE
Fix possession team change for EPA

### DIFF
--- a/R/ExpectedPointAndWinProbability.R
+++ b/R/ExpectedPointAndWinProbability.R
@@ -323,7 +323,8 @@ expected_points <- function(dataset) {
                                                         dplyr::lead(PlayType) %in% c("Quarter End",
                                                                                      "Two Minute Warning",
                                                                                      "Timeout") &
-                                                        (Drive != dplyr::lead(Drive,2)), 1, 0))
+                                                        (Drive != dplyr::lead(Drive,2)),
+                                                        (posteam != dplyr::lead(posteam,2)), 1, 0))
   pbp_data_epa$EPA_base_nxt_ind <- with(pbp_data_epa,
                                         ifelse(GameID == dplyr::lead(GameID) & 
                                                  GameID == dplyr::lead(GameID,2) &

--- a/R/ExpectedPointAndWinProbability.R
+++ b/R/ExpectedPointAndWinProbability.R
@@ -335,6 +335,7 @@ expected_points <- function(dataset) {
   pbp_data_epa$EPA_change_no_score_ind <- with(pbp_data_epa,
                                                ifelse(GameID == dplyr::lead(GameID) & 
                                                         Drive != dplyr::lead(Drive) &
+                                                        posteam != dplyr::lead(posteam) &
                                                         dplyr::lead(PlayType) %in% 
                                                         c("Pass","Run","Punt","Sack",
                                                           "Field Goal","No Play",

--- a/R/ExpectedPointAndWinProbability.R
+++ b/R/ExpectedPointAndWinProbability.R
@@ -323,7 +323,7 @@ expected_points <- function(dataset) {
                                                         dplyr::lead(PlayType) %in% c("Quarter End",
                                                                                      "Two Minute Warning",
                                                                                      "Timeout") &
-                                                        (Drive != dplyr::lead(Drive,2)),
+                                                        (Drive != dplyr::lead(Drive,2)) &
                                                         (posteam != dplyr::lead(posteam,2)), 1, 0))
   pbp_data_epa$EPA_base_nxt_ind <- with(pbp_data_epa,
                                         ifelse(GameID == dplyr::lead(GameID) & 


### PR DESCRIPTION
Only was checking drive number before, but need to ensure possession team actually changes (muffed punts for instance).