### PR TITLE
airWPA and yacWPA

### DIFF
--- a/R/PlayByPlayBoxScore.R
+++ b/R/PlayByPlayBoxScore.R
@@ -185,6 +185,8 @@
 #'  \item{"Win_Prob"} - The win probability added for team with possession
 #'  \item{"WPA"} - The win probability added with respect to the
 #'  possession team
+#'  \item{"airWPA"} - Win probability added from air yards
+#'  \item{"yacWPA"} - Win probability added from yards after catch
 #'  
 #'  }
 #'  
@@ -1489,7 +1491,7 @@ game_play_by_play <- function(GameID) {
          "Opp_Touchdown_Prob","Field_Goal_Prob","Safety_Prob",
          "Touchdown_Prob","ExPoint_Prob","TwoPoint_Prob",
          "ExpPts","EPA","airEPA","yacEPA","Home_WP_pre",  "Away_WP_pre", "Home_WP_post", 
-         "Away_WP_post","Win_Prob","WPA")]
+         "Away_WP_post","Win_Prob","WPA","airWPA","yacWPA")]
 }
 
 ################################################################## 

--- a/man/game_play_by_play.Rd
+++ b/man/game_play_by_play.Rd
@@ -194,6 +194,8 @@ The added variables are specified below:
  \item{"Win_Prob"} - The win probability added for team with possession
  \item{"WPA"} - The win probability added with respect to the
  possession team
+ \item{"airWPA"} - Win probability added from air yards
+ \item{"yacWPA"} - Win probability added from yards after catch
  
  }
 }

--- a/man/season_play_by_play.Rd
+++ b/man/season_play_by_play.Rd
@@ -4,15 +4,11 @@
 \alias{season_play_by_play}
 \title{Parsed Descriptive Play-by-Play Function for a Full Season}
 \usage{
-season_play_by_play(Season, Weeks = 16)
+season_play_by_play(Season)
 }
 \arguments{
 \item{Season}{(numeric) A 4-digit year corresponding to an NFL season of 
 interest}
-
-\item{Weeks}{(numeric) A number corresponding to the number of weeks of data
-you want to be scraped and included in the output. If you input 3, the first
-three weeks of play-by-play will be scraped from the associated season.}
 }
 \value{
 A dataframe contains all the play-by-play information for a single


### PR DESCRIPTION
Calculate the airWPA and yacWPA for every passing attempt using the airEPA to adjust the expected score differential. This was done by taking a similar approach to calculating the airEPA, the hypothetical of what would happen if the ball only traveled the distance of the air yards, calculating the win probability at the distance and simply taking the difference between WPA and airWPA to arrive at the yacWPA.