### PR TITLE
Newscrape

### DIFF
--- a/R/PlayByPlayBoxScore.R
+++ b/R/PlayByPlayBoxScore.R
@@ -9,7 +9,8 @@
 #' @description This function intakes the JSON play-by-play data of a single
 #'  game and parses the play description column into individual variables 
 #'  allowing the user to segment the game in a variety of different ways for 
-#'  model building and analysis.
+#'  model building and analysis. WARNING: This function is deprecated and will be removed from the package
+#'  after the 2018-19 season.
 #' @param GameID (character or numeric) A 10 digit game ID associated with a 
 #' given NFL game.
 #' @details Through list manipulation using the do.call and rbind functions
@@ -1502,6 +1503,8 @@ game_play_by_play <- function(GameID) {
 #' @description This function outputs all plays of an entire season in one dataframe.  
 #' It calls the game_play_by_play function and applies it over every 
 #' game in the season by extracting each game ID and url in the specified season.
+#' WARNING: This function is deprecated and will be removed from the package
+#' after the 2018-19 season.
 #' 
 #' @param Season (numeric) A 4-digit year corresponding to an NFL season of 
 #' interest
@@ -1522,7 +1525,7 @@ game_play_by_play <- function(GameID) {
 #' @export
 season_play_by_play <- function(Season) {
   # Google R style format
-  
+
   # Below the function put together the proper URLs for each game in each 
   # season and runs the game_play_by_play function across the entire season
   game_ids <- extracting_gameids(Season)

--- a/R/add_ep_wp_variables.R
+++ b/R/add_ep_wp_variables.R
@@ -322,6 +322,26 @@ add_ep_variables <- function(pbp_data) {
                                          drive != dplyr::lead(drive, 2) &
                                          posteam != dplyr::lead(posteam, 2),
                                        -dplyr::lead(ExpPts, 2) - ExpPts, EPA),
+                  # Same thing except for when back to back rows of end of
+                  # play that can potentially occur because the NFL likes to 
+                  # make my life difficult:
+                  EPA = dplyr::if_else(is.na(td_team) & field_goal_made == 0 &
+                                         extra_point_good == 0 &
+                                         extra_point_failed == 0 &
+                                         extra_point_blocked == 0 &
+                                         extra_point_aborted == 0 &
+                                         two_point_rush_failed == 0 &
+                                         two_point_pass_failed == 0 &
+                                         two_point_pass_reception_failed == 0 &
+                                         two_point_rush_good == 0 &
+                                         two_point_pass_good == 0 &
+                                         two_point_pass_reception_good == 0 &
+                                         safety == 0 &
+                                         (is.na(dplyr::lead(play_type)) &
+                                            is.na(dplyr::lead(play_type, 2))) &
+                                         drive != dplyr::lead(drive, 3) &
+                                         posteam != dplyr::lead(posteam, 3),
+                                       -dplyr::lead(ExpPts, 3) - ExpPts, EPA),                  
                   # Team keeps possession and no timeout or end of play follows:
                   EPA = dplyr::if_else(is.na(td_team) & field_goal_made == 0 &
                                          extra_point_good == 0 &
@@ -355,7 +375,24 @@ add_ep_variables <- function(pbp_data) {
                                          (is.na(dplyr::lead(play_type)) |
                                             dplyr::lead(timeout) == 1) &
                                          posteam == dplyr::lead(posteam, 2),
-                                       dplyr::lead(ExpPts, 2) - ExpPts, EPA)) %>%
+                                       dplyr::lead(ExpPts, 2) - ExpPts, EPA),
+                  # Same as above but when two rows without play info follow:
+                  EPA = dplyr::if_else(is.na(td_team) & field_goal_made == 0 &
+                                         extra_point_good == 0 &
+                                         extra_point_failed == 0 &
+                                         extra_point_blocked == 0 &
+                                         extra_point_aborted == 0 &
+                                         two_point_rush_failed == 0 &
+                                         two_point_pass_failed == 0 &
+                                         two_point_pass_reception_failed == 0 &
+                                         two_point_rush_good == 0 &
+                                         two_point_pass_good == 0 &
+                                         two_point_pass_reception_good == 0 &
+                                         safety == 0 &
+                                         (is.na(dplyr::lead(play_type)) &
+                                            is.na(dplyr::lead(play_type, 2))) &
+                                         posteam == dplyr::lead(posteam, 3),
+                                       dplyr::lead(ExpPts, 3) - ExpPts, EPA)) %>%
     # Now rename each of the expected points columns to match the style of
     # the updated code:
     dplyr::rename(ep = ExpPts, epa = EPA,

--- a/man/game_play_by_play.Rd
+++ b/man/game_play_by_play.Rd
@@ -18,7 +18,8 @@ outcomes associated with each play of the specified NFL game.
 This function intakes the JSON play-by-play data of a single
  game and parses the play description column into individual variables 
  allowing the user to segment the game in a variety of different ways for 
- model building and analysis.
+ model building and analysis. WARNING: This function is deprecated and will be removed from the package
+ after the 2018-19 season.
 }
 \details{
 Through list manipulation using the do.call and rbind functions

--- a/man/scrape_game_play_by_play.Rd
+++ b/man/scrape_game_play_by_play.Rd
@@ -44,3 +44,12 @@ This function acts as a wrapper function for the
 \code{\link{scrape_json_play_by_play}} and \code{\link{scrape_html_play_by_play}} 
 functions, deciding which to use depending on the input.
 }
+\examples{
+# Scrape the play-by-play data for the 2017 Super Bowl by first getting all
+# of the post-season game ids then use the required info to scrape the 
+# play-by-play data (knowing that it's the last game):
+playoff_game_ids_17 <- scrape_game_ids(2017, type = "post")
+sb_17_id <- playoff_game_ids_17$game_id[nrow(playoff_game_ids_17)]
+sb_17_pbp <- scrape_game_play_by_play(game_id = sb_17_id, type = "post", 
+                                      season = 2017)
+}

--- a/man/scrape_json_play_by_play.Rd
+++ b/man/scrape_json_play_by_play.Rd
@@ -339,9 +339,27 @@ challenge.
 \item{replay_or_challenge_result} - String indicating the result of the 
 replay or challenge.
 \item{penalty_type} - String indicating the penalty type.
+\item{defensive_two_point_attempt} - Binary indicator whether or not the defense
+was able to have an attempt on a two point conversion, this results following
+a turnover.
+\item{defensive_two_point_conv} - Binary indicator whether or not the defense
+successfully scored on the two point conversion.
+\item{defensive_extra_point_attempt} - Binary indicator whether or not the 
+defense was able to have an attempt on an extra point attempt, this results
+following a blocked attempt that the defense recovers the ball.
+\item{defensive_extra_point_conv} - Binary indicator whether or not the
+defense successfully scored on an extra point attempt. 
 }
 }
 \description{
 This function returns the play-by-play data available from NFL.com's JSON feed 
 (for games starting in 2009).
+}
+\examples{
+# Scrape the play-by-play data for the 2017 Super Bowl by first getting all
+# of the post-season game ids then use the required info to scrape the 
+# play-by-play data (knowing that it's the last game):
+playoff_game_ids_17 <- scrape_game_ids(2017, type = "post")
+sb_17_id <- playoff_game_ids_17$game_id[nrow(playoff_game_ids_17)]
+sb_17_pbp <- scrape_json_play_by_play(game_id = sb_17_id)
 }

--- a/man/scrape_season_play_by_play.Rd
+++ b/man/scrape_season_play_by_play.Rd
@@ -43,3 +43,12 @@ This function acts as a wrapper function for calling the
 \code{\link{scrape_game_play_by_play}} function over all of the games meeting
 the criteria of the user's input.
 }
+\examples{
+# Scrape the play-by-play data for the 2017 Super Bowl by first getting all
+# of the post-season game ids then use the required info to scrape the 
+# play-by-play data (knowing that it's the last game):
+playoff_game_ids_17 <- scrape_game_ids(2017, type = "post")
+sb_17_id <- playoff_game_ids_17$game_id[nrow(playoff_game_ids_17)]
+sb_17_pbp <- scrape_game_play_by_play(game_id = sb_17_id, type = "post", 
+                                      season = 2017)
+}

--- a/man/season_play_by_play.Rd
+++ b/man/season_play_by_play.Rd
@@ -20,6 +20,8 @@ A dataframe contains all the play-by-play information for a single
 This function outputs all plays of an entire season in one dataframe.  
 It calls the game_play_by_play function and applies it over every 
 game in the season by extracting each game ID and url in the specified season.
+WARNING: This function is deprecated and will be removed from the package
+after the 2018-19 season.
 }
 \details{
 This function calls the extracting_gameids, 


### PR DESCRIPTION
Fix the issues regarding the defensive point conversion stat ids that were preventing data from scraping, handle penalties properly such as roughing the passer on completions that were being marked as no play which should have been recorded as passes, and also add warning in documentation for the old play-by-play scraping.