### PR TITLE
Modified logic of replay_or_challenge flag to pick up coaches challenges

### DIFF
--- a/R/scrape_play_by_play.R
+++ b/R/scrape_play_by_play.R
@@ -2383,7 +2383,7 @@ scrape_json_play_by_play <- function(game_id, check_url = 1) {
                                                           quarter_seconds_remaining),
                   # Add column for replay or challenge:
                   replay_or_challenge = stringr::str_detect(desc, 
-                                                            "(Replay Official reviewed)|( challenge )") %>%
+                                                            "(Replay Official reviewed)|( challenged )") %>%
                     as.numeric(),
                   # Result of replay or challenge:
                   replay_or_challenge_result = dplyr::if_else(replay_or_challenge == 1,


### PR DESCRIPTION
Modified the target for the str_detect() command to pick up *"(Replay Official reviewed)|( challenged )"* instead of *"(Replay Official reviewed)|( challenge )"*

Tested on 2017 regular season pbp data and it reconciled the coaches challenges to article [Coaches’ reversal rate drops while replay booth reversal rate soars](http://www.footballzebras.com/2018/01/reversals-in-replay-dip-after-controversial-season/)

Pre-change: 2017 regular season (replay_or_challenge == 1): 249
Post-change: 2017 regular season (replay_or_challenge == 1): 431

i.e. Coaches challenges = 182
