### PR TITLE
Tweaks to get_rosters() for speed and birthdates

### DIFF
--- a/R/get_rosters.R
+++ b/R/get_rosters.R
@@ -155,8 +155,9 @@ get_gsis_id <- . %>%
 #' For a player's href, get their birthdate from their personal url.
 get_birthdate <- . %>%
   paste("http://www.nfl.com", ., sep = "") %>%
-  rvest::html_nodes('p:nth-child(4)') %>% 
-  rvest::html_text() %>% 
+  rvest::html_nodes('#player-bio p') %>%
+  rvest::html_text() %>%
+  .[grep("Born", .)] %>%
   stringr::str_extract("[0-9]+/[0-9]+/[0-9]+") %>% 
   lubridate::mdy() %>% 
   as.character()
@@ -167,7 +168,7 @@ get_birthdate <- . %>%
 find_page_player_birthdate <- . %>%
   rvest::html_nodes("td:nth-child(2) a") %>% 
   rvest::html_attr("href") %>%
-  purrr::map_chr(get_gsis_id)
+  purrr::map_chr(get_birthdate)
 
 
 # DO NOT EXPORT


### PR DESCRIPTION
Hiya! I was looking for a way to scrape player birthdates that would match GSIS IDs and figured that I'd go in and use a similar method as set out in the get_rosters() function. I think this could be useful for others too :)

Also, I rearranged the "readHTML" so that it wouldn't be run duplicate times, and limited readlines to 1000 lines so that it would operate a bit faster (GSIS ID is usually in the first ~600 lines)