### PR TITLE
add furrr processing for season pbp scrape

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: This package allows data driven sports enthusiasts to use the NFL J
     professional NFL teams as well as the public.
 Depends: R (>= 3.5.0),
          nnet (>= 7.3.12),
-    magrittr
+         magrittr
 Imports: RJSONIO (>= 1.3.0),
          RCurl (>= 1.95.4.11),
          stringr (>= 1.3.1),
@@ -31,7 +31,9 @@ Imports: RJSONIO (>= 1.3.0),
          xml2 (>= 1.2.0),
          hashmap (>= 0.2.2),
          assertthat (>= 0.2.0),
-         tidyr (>= 0.8.1)
+         tidyr (>= 0.8.1),
+         furrr (>= 0.1.0),
+         future (>= 1.15.0)
 Suggests: testthat,
           knitr,
           rmarkdown
@@ -39,5 +41,5 @@ License: CC0
 URL: https://github.com/maksimhorowitz/nflscrapR
 BugReports: https://github.com/maksimhorowitz/nflscrapR/issues
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 7.0.2
 VignetteBuilder: knitr

--- a/man/scrape_season_play_by_play.Rd
+++ b/man/scrape_season_play_by_play.Rd
@@ -4,8 +4,13 @@
 \alias{scrape_season_play_by_play}
 \title{Scrape season play-by-play for a given NFL season (either pre, regular, or post-season)}
 \usage{
-scrape_season_play_by_play(season, type = "reg", weeks = NULL,
-  teams = NULL)
+scrape_season_play_by_play(
+  season,
+  type = "reg",
+  weeks = NULL,
+  teams = NULL,
+  furrr = FALSE
+)
 }
 \arguments{
 \item{season}{Numeric 4-digit year associated with an NFL season}


### PR DESCRIPTION
Hiya! I was experimenting with the furrr package for parallel processing after watching some of the rstudioconf 2020 talks, and got some pretty great results on the scrape_season_pbp function - sharing them here, I can go through and look at more of the functions if you guys think it's worth adding more globally across the package. 

Here's my "test" version of the scrape_season_pbp code with changes highlighted - it adds a "furrr" argument to the function which defaults to FALSE - you have to choose to turn it on by sending furrr=TRUE in the function call. 

![image](https://user-images.githubusercontent.com/38083823/75118147-94f46c00-5645-11ea-97f6-b777a2416b74.png)

On my machine (i7-8850H 6-core CPU) this resulted in 4x speed increases over the original code 😎 

![image](https://user-images.githubusercontent.com/38083823/75118204-0f24f080-5646-11ea-9660-f19cfab6b5b3.png)
