### PR TITLE
Fixed the Issue on Plays with a completed pass, YAC 0, and accepted penalty where air_epa was incorrect

### DIFF
--- a/R/add_ep_wp_variables.R
+++ b/R/add_ep_wp_variables.R
@@ -573,12 +573,13 @@ add_air_yac_ep_variables <- function(pbp_data) {
   # Calculate the yards after catch EPA:
   pass_pbp_data <- dplyr::mutate(pass_pbp_data, yacEPA = epa - airEPA)
   
+  
   # if Yards after catch is 0 make yacEPA set to 0:
-  pass_pbp_data$yacEPA <- ifelse(pass_pbp_data$yards_after_catch == 0 & pass_pbp_data$complete_pass==1,
+  pass_pbp_data$yacEPA <- ifelse(pass_pbp_data$penalty == 0 & pass_pbp_data$yards_after_catch == 0 & pass_pbp_data$complete_pass==1,
                                  0, pass_pbp_data$yacEPA)
   
   # if Yards after catch is 0 make airEPA set to EPA:
-  pass_pbp_data$airEPA <- ifelse(pass_pbp_data$yards_after_catch == 0 & pass_pbp_data$complete_pass == 1,
+  pass_pbp_data$airEPA <- ifelse(pass_pbp_data$penalty == 0 & pass_pbp_data$yards_after_catch == 0 & pass_pbp_data$complete_pass == 1,
                                  pass_pbp_data$epa, pass_pbp_data$airEPA)
   
   # Now add airEPA and yacEPA to the original dataset:
@@ -1253,11 +1254,11 @@ add_air_yac_wp_variables <- function(pbp_data) {
   }
   
   # if Yards after catch is 0 make yacWPA set to 0:
-  pass_pbp_data$yacWPA <- ifelse(pass_pbp_data$yards_after_catch == 0 & 
+  pass_pbp_data$yacWPA <- ifelse(pass_pbp_data$penalty == 0 & pass_pbp_data$yards_after_catch == 0 & 
                                    pass_pbp_data$complete_pass == 1,
                                  0, pass_pbp_data$yacWPA)
   # if Yards after catch is 0 make airWPA set to WPA:
-  pass_pbp_data$airWPA <- ifelse(pass_pbp_data$yards_after_catch == 0 &
+  pass_pbp_data$airWPA <- ifelse(pass_pbp_data$penalty == 0 & pass_pbp_data$yards_after_catch == 0 &
                                    pass_pbp_data$complete_pass == 1,
                                  pass_pbp_data$wpa, pass_pbp_data$airWPA)
   


### PR DESCRIPTION
There was an issue on pass plays with YAC 0, if there is an accepted penalty, then air_epa became epa rather than YAC epa being set to epa-air_epa. 

The analogous issue was happening with air_wpa and yac_wpa. I added the check for both cases to prevent this issue from happening. 

